### PR TITLE
feat: migrate to Docker/ECR/Lambda container deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,27 +3,24 @@ name: Deploy to AWS
 on:
   push:
     branches: [ main ]
-    paths:
-      - 'nextjs-app/**'
-      - 'aws/**'
   workflow_dispatch:  # Allow manual trigger
+
+env:
+  ECR_REPOSITORY: joono-prd-portfolio
+  LAMBDA_FUNCTION_NAME: joono-prd-portfolio-fn
+  CLOUDFRONT_ALIAS: joono.work
 
 jobs:
   deploy:
-    name: Deploy Next.js App to AWS
+    name: Build and Deploy Container Image
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '22'
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
@@ -31,56 +28,80 @@ jobs:
         role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
         aws-region: ${{ secrets.AWS_REGION }}
 
-    - name: Install CDK dependencies
-      run: npm ci
-      working-directory: aws
+    - name: Log in to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
 
-    - name: Install Next.js dependencies
-      run: npm ci
-      working-directory: nextjs-app
-
-    - name: Build Next.js app
+    - name: Build Docker image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
       run: |
-        npm run build
-        echo "✅ Next.js build completed"
-        ls -la .next/
-      working-directory: nextjs-app
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} ./nextjs-app
+        echo "✅ Docker image built: $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}"
 
-    - name: Copy build artifacts to CDK
+    - name: Push Docker image (commit SHA tag)
+      continue-on-error: false
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
       run: |
-        # Ensure CDK can access the built Next.js app
-        cp -r nextjs-app/.next aws/
-        cp -r nextjs-app/public aws/ 2>/dev/null || true
-        cp nextjs-app/package.json aws/
-        cp nextjs-app/package-lock.json aws/
-        echo "✅ Build artifacts copied to CDK directory"
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
+        echo "✅ Pushed image with SHA tag: ${{ github.sha }}"
 
-    - name: CDK Bootstrap (if needed)
-      run: npx cdk bootstrap
-      working-directory: aws
+    - name: Tag and push Docker image (latest tag)
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      run: |
+        docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} $ECR_REGISTRY/$ECR_REPOSITORY:latest
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+        echo "✅ Pushed image with latest tag"
+
+    - name: Update Lambda function code
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      run: |
+        aws lambda update-function-code \
+          --function-name $LAMBDA_FUNCTION_NAME \
+          --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
+        echo "✅ Lambda updated to image: $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}"
+
+    - name: Resolve CloudFront distribution ID
+      id: resolve-cf
       continue-on-error: true
-
-    - name: CDK Deploy Portfolio Lambda
       run: |
-        echo "🚀 Deploying Next.js app with latest build..."
-        npx cdk deploy PortfolioCdkStack --require-approval never --verbose
-        echo "✅ CDK deployment completed"
-      working-directory: aws
-
-    - name: Invalidate CloudFront Cache
-      run: |
-        DISTRIBUTION_ID=$(aws cloudfront list-distributions --query "DistributionList.Items[?contains(Aliases.Items, 'joono.work')].Id" --output text)
-        if [ ! -z "$DISTRIBUTION_ID" ]; then
-          aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths "/*"
-          echo "✅ CloudFront cache invalidated for distribution: $DISTRIBUTION_ID"
+        DISTRIBUTION_ID=$(aws cloudfront list-distributions \
+          --query "DistributionList.Items[?contains(Aliases.Items, '$CLOUDFRONT_ALIAS')].Id" \
+          --output text)
+        if [ -z "$DISTRIBUTION_ID" ]; then
+          echo "⚠️ No CloudFront distribution found for alias: $CLOUDFRONT_ALIAS"
+          echo "distribution_id=" >> $GITHUB_OUTPUT
+        else
+          echo "✅ Found CloudFront distribution: $DISTRIBUTION_ID"
+          echo "distribution_id=$DISTRIBUTION_ID" >> $GITHUB_OUTPUT
         fi
 
-    - name: Deployment Summary
+    - name: Invalidate CloudFront cache
+      continue-on-error: true
+      env:
+        DISTRIBUTION_ID: ${{ steps.resolve-cf.outputs.distribution_id }}
+      run: |
+        if [ -z "$DISTRIBUTION_ID" ]; then
+          echo "⚠️ Skipping CloudFront invalidation — no distribution ID resolved"
+          exit 0
+        fi
+        aws cloudfront create-invalidation \
+          --distribution-id $DISTRIBUTION_ID \
+          --paths "/*"
+        echo "✅ CloudFront cache invalidated for distribution: $DISTRIBUTION_ID"
+
+    - name: Write deployment summary
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
       run: |
         echo "# 🚀 Deployment Summary" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "**Status:** ✅ Successfully deployed with latest Next.js build" >> $GITHUB_STEP_SUMMARY
-        echo "**Website:** https://joono.work" >> $GITHUB_STEP_SUMMARY
-        echo "**Deployed at:** $(date)" >> $GITHUB_STEP_SUMMARY
-        echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
-        echo "**Build artifacts:** Next.js app built and deployed to Lambda" >> $GITHUB_STEP_SUMMARY
+        echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+        echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+        echo "| **Commit SHA** | \`${{ github.sha }}\` |" >> $GITHUB_STEP_SUMMARY
+        echo "| **Image Tag** | \`$ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}\` |" >> $GITHUB_STEP_SUMMARY
+        echo "| **Deployed At** | \`$(date -u +"%Y-%m-%dT%H:%M:%SZ")\` |" >> $GITHUB_STEP_SUMMARY
+        echo "| **Website** | https://joono.work |" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .DS_Store
 *.log
 .husky/_
+.kiro

--- a/aws/README.md
+++ b/aws/README.md
@@ -4,25 +4,110 @@ This project contains the AWS CDK infrastructure code for the personal portfolio
 
 ## CDK Stacks
 
-### PortfolioNotificationStack
-Manages SNS topics and notifications for monitoring and alerting purposes.
+All stacks follow the `joono-prd-<service>` naming convention.
 
-### PortfolioCdkStack
-Core infrastructure stack containing Lambda functions, API Gateway, and DynamoDB tables for backend services (e.g., page view tracking).
+| Stack Name | Description | Status |
+|---|---|---|
+| `joono-prd-ecr` | ECR repository for Docker images of the Next.js app | New |
+| `joono-prd-portfolio` | Container Lambda, Lambda Function URL, DynamoDB | Renamed from `PortfolioCdkStack` |
+| `joono-prd-notifications` | SNS/SQS notifications, API Gateway, Ingest/Processor Lambdas | Renamed from `PortfolioNotificationStack` |
+| `joono-prd-github-actions-role` | IAM OIDC provider and GitHubActionsRole for CI/CD | Renamed from `GitHubActionsRole` |
+| `joono-prd-hostedzone` | Route 53 hosted zone for DNS management | Unchanged |
+| `joono-prd-global-certificate` | ACM certificate for HTTPS/SSL (us-east-1) | Unchanged |
+| `joono-prd-website` | CloudFront distribution and S3 bucket for the website | Unchanged |
+
+### joono-prd-ecr
+
+New stack. Defines the ECR repository that stores versioned Docker images of the Next.js app.
+
+- **Repository name:** `joono-prd-portfolio`
+- **Tag immutability:** ENABLED — once a tag is pushed it cannot be overwritten
+- **Lifecycle policy:** Retains a maximum of 10 tagged images; untagged images are removed after 7 days
+
+### joono-prd-portfolio
+
+Core infrastructure stack. The Lambda function runs the Next.js app as a container image pulled from ECR.
+
+- **Lambda function:** `joono-prd-portfolio-fn` — 512 MB memory, 30 s timeout, `PackageType: Image`
+- **Image source:** `DockerImageCode.fromEcr()` pointed at the `joono-prd-portfolio` ECR repository
+- **Function URL:** Auth type `AWS_IAM`, used as the CloudFront origin via Origin Access Control
+
+### joono-prd-notifications
+
+Manages the page view notification pipeline.
+
+- HTTP API Gateway (`/pageview` POST endpoint)
+- SQS FIFO Queue (`PageViewQueue.fifo`) — deduplicates messages by visitor IP within a 5-minute window
+- Ingest Lambda — receives events from API Gateway and enqueues to the FIFO queue
+- Processor Lambda — reads from the FIFO queue and sends email via SES
+
+### joono-prd-github-actions-role
+
+IAM role with the permissions required for GitHub Actions to deploy infrastructure and application updates via OIDC (no long-lived credentials stored as secrets).
 
 ### joono-prd-hostedzone
-Route 53 hosted zone for DNS management of the production domain.
+
+Route 53 hosted zone for DNS management of the production domain (`joono.work`).
 
 ### joono-prd-global-certificate
-ACM (AWS Certificate Manager) certificate for HTTPS/SSL, deployed in us-east-1 region (required for CloudFront).
+
+ACM (AWS Certificate Manager) certificate for HTTPS/SSL, deployed in `us-east-1` (required for CloudFront).
 
 ### joono-prd-website
-CloudFront distribution, S3 bucket, and related resources for hosting and serving the static Next.js website.
 
-### GitHubActionsRole
-IAM role with necessary permissions for GitHub Actions to deploy infrastructure and application updates via CI/CD pipeline.
+CloudFront distribution, S3 bucket, and related resources for hosting and serving the Next.js website.
 
-## Useful commands
+---
+
+## ECR Image Tags
+
+Every push to `main` produces exactly two tags for the same image digest:
+
+| Tag | Format | Example | Purpose |
+|---|---|---|---|
+| Commit SHA | `[0-9a-f]{40}` | `a3f8c1d2e4b6...` | Immutable, traceable to the exact commit |
+| Latest | `latest` | `latest` | Convenience pointer for manual pulls |
+
+The Lambda function is always updated to the **commit-SHA tag** (never `latest`) so the deployed version is unambiguous and rollback is straightforward.
+
+---
+
+## CI/CD Pipeline
+
+The GitHub Actions workflow triggers automatically on every push to `main` and can also be triggered manually via `workflow_dispatch`.
+
+### Pipeline Sequence
+
+```
+push to main
+  └─ 1.  Checkout code
+  └─ 2.  Configure AWS credentials (OIDC → GitHubActionsRole)
+  └─ 3.  Log in to ECR
+  └─ 4.  docker build -t joono-prd-portfolio:$SHA ./nextjs-app
+  └─ 5.  docker push joono-prd-portfolio:$SHA
+  └─ 6.  docker tag joono-prd-portfolio:$SHA joono-prd-portfolio:latest
+  └─ 7.  docker push joono-prd-portfolio:latest
+  └─ 8.  aws lambda update-function-code --image-uri <ecr-uri>:$SHA
+  └─ 9.  Resolve CloudFront distribution ID by alias joono.work
+  └─ 10. aws cloudfront create-invalidation --paths "/*"
+  └─ 11. Write job summary (SHA, image tag, timestamp)
+```
+
+Steps 1–8 are required: any failure halts the workflow and leaves the previous Lambda image active. Steps 9–10 (CloudFront lookup and invalidation) use `continue-on-error: true` so a cache invalidation failure never blocks a successful deployment.
+
+### IAM Permissions
+
+The `GitHubActionsRole` is granted the following scoped permissions:
+
+- **ECR:** `ecr:GetAuthorizationToken`, `ecr:BatchCheckLayerAvailability`, `ecr:PutImage`, `ecr:InitiateLayerUpload`, `ecr:UploadLayerPart`, `ecr:CompleteLayerUpload` on the `joono-prd-portfolio` repository
+- **Lambda:** `lambda:UpdateFunctionCode` on `joono-prd-portfolio-fn`
+- **CloudFront:** `cloudfront:CreateInvalidation` on the `joono.work` distribution
+
+The role retains `PowerUserAccess` until the scoped permissions above are validated in production, after which `PowerUserAccess` will be removed.
+
+---
+
+## Useful Commands
 
 * `npm run build`   compile typescript to js
 * `npm run watch`   watch for changes and compile
@@ -32,8 +117,64 @@ IAM role with necessary permissions for GitHub Actions to deploy infrastructure 
 * `npx cdk synth`   emits the synthesized CloudFormation template
 * `cdk list`        list all stacks in the app
 
+---
+
 ## CloudFront Cache Invalidation
 
-* `aws cloudfront list-distributions --query "DistributionList.Items[*].[Id,DomainName]" --output table` - list all distributions
-* `aws cloudfront create-invalidation --distribution-id DISTRIBUTION_ID --paths "/*"` - invalidate cache for all files
-* `aws cloudfront create-invalidation --distribution-id DISTRIBUTION_ID --paths "/index.html" "/projects/*"` - invalidate specific paths 
+```bash
+# List all distributions
+aws cloudfront list-distributions \
+  --query "DistributionList.Items[*].[Id,DomainName]" \
+  --output table
+
+# Invalidate all files
+aws cloudfront create-invalidation \
+  --distribution-id DISTRIBUTION_ID \
+  --paths "/*"
+
+# Invalidate specific paths
+aws cloudfront create-invalidation \
+  --distribution-id DISTRIBUTION_ID \
+  --paths "/index.html" "/projects/*"
+```
+
+---
+
+## Migration Notes
+
+> **Required reading before renaming stateful stacks.**
+
+Renaming a CloudFormation stack causes CloudFormation to treat the rename as a delete-and-recreate operation. For stacks that hold stateful resources (DynamoDB tables, SQS queues, S3 buckets), this would destroy live data. The following manual steps **must** be completed before applying any stack rename.
+
+### Renaming `PortfolioCdkStack` → `joono-prd-portfolio`
+
+This stack contains a DynamoDB table (page view tracking). Before renaming:
+
+1. **Export the DynamoDB table** — use `aws dynamodb create-backup` or enable point-in-time recovery to preserve data.
+2. **Remove the table from the old stack** — update the CDK code to remove the `DynamoDB.Table` construct from `PortfolioCdkStack` and deploy. This detaches the table from CloudFormation without deleting it (set `removalPolicy: RETAIN`).
+3. **Import the table into the new stack** — after deploying the renamed `joono-prd-portfolio` stack, use `cdk import` to bring the existing table under the new stack's management.
+4. **Verify** — run `cdk diff` to confirm no destructive changes are planned before deploying.
+
+### Renaming `PortfolioNotificationStack` → `joono-prd-notifications`
+
+This stack contains an SQS FIFO queue. Before renaming:
+
+1. **Drain the queue** — ensure no in-flight messages are present (`ApproximateNumberOfMessages` and `ApproximateNumberOfMessagesNotVisible` are both 0).
+2. **Set `removalPolicy: RETAIN`** on the SQS queue construct and deploy to detach it from the old stack without deletion.
+3. **Deploy the renamed stack** — the new `joono-prd-notifications` stack will create a fresh queue. Use `cdk import` if you need to bring the existing queue under the new stack.
+4. **Verify** — confirm the Ingest Lambda's `QUEUE_URL` environment variable points to the correct queue ARN after the rename.
+
+### Renaming `GitHubActionsRole` → `joono-prd-github-actions-role`
+
+This stack contains only IAM resources (stateless from a data perspective). The rename is lower risk, but:
+
+1. **Pause CI/CD pipelines** — ensure no GitHub Actions workflows are running while the role is being recreated.
+2. **Deploy the renamed stack** — CloudFormation will delete the old role and create a new one with the same trust policy and permissions.
+3. **Verify OIDC** — trigger a test workflow run to confirm the new role is assumed successfully before re-enabling automated deployments.
+
+### General Checklist
+
+- [ ] Run `cdk diff` before every rename deployment and review for `[-]` (delete) actions on stateful resources
+- [ ] Set `removalPolicy: RETAIN` on any resource you do not want CloudFormation to delete
+- [ ] Use `cdk import` to bring retained resources under the new stack without recreation
+- [ ] Coordinate renames during a low-traffic maintenance window

--- a/aws/bin/main.ts
+++ b/aws/bin/main.ts
@@ -2,6 +2,7 @@
 import * as cdk from 'aws-cdk-lib';
 import "dotenv/config";
 import { PortfolioCdkStack } from '../lib/portfoliostack';
+import { EcrStack } from '../lib/ecr-stack';
 import { HostedZoneStack } from '../lib/hosted-zone-stack';
 import { CertificateStack } from '../lib/certificate-stack';
 import { WebsiteStack } from '../lib/website-stack';
@@ -14,12 +15,23 @@ const domain = 'joono.work';
 const app = new cdk.App();
 
 // Email notification system for contact forms
-new PortfolioNotificationStack(app, "PortfolioNotificationStack", {
-  env: { region: process.env.AWS_REGION },
+new PortfolioNotificationStack(app, "joono-prd-notifications", {
+  stackName: 'joono-prd-notifications',
+  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 });
 
-// Main Next.js application deployed as Lambda function
-new PortfolioCdkStack(app, "PortfolioCdkStack", {
+// ECR repository for container images
+const ecrStack = new EcrStack(app, "joono-prd-ecr", {
+  stackName: 'joono-prd-ecr',
+  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+});
+
+// Main Next.js application deployed as container Lambda function
+new PortfolioCdkStack(app, "joono-prd-portfolio", {
+  stackName: 'joono-prd-portfolio',
+  ecrRepo: ecrStack.repository,
+  // imageTag defaults to 'latest'; the pipeline overrides this with the commit SHA at deploy time
+
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */
@@ -27,10 +39,6 @@ new PortfolioCdkStack(app, "PortfolioCdkStack", {
   /* Uncomment the next line to specialize this stack for the AWS Account
    * and Region that are implied by the current CLI configuration. */
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
-
-  /* Uncomment the next line if you know exactly what Account and Region you
-   * want to deploy the stack to. */
-  // env: { account: "730335304134", region: "ap-southeast-4" },
 
   /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
 });
@@ -68,7 +76,8 @@ new WebsiteStack(app, "joono-prd-website", {
 });
 
 // GitHub Actions OIDC Role for CI/CD
-new GitHubActionsRole(app, 'GitHubActionsRole', {
+new GitHubActionsRole(app, 'joono-prd-github-actions-role', {
+  stackName: 'joono-prd-github-actions-role',
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,

--- a/aws/lib/ecr-stack.ts
+++ b/aws/lib/ecr-stack.ts
@@ -1,0 +1,32 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+
+export class EcrStack extends cdk.Stack {
+  public readonly repository: ecr.Repository;
+
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    this.repository = new ecr.Repository(this, 'PortfolioRepository', {
+      repositoryName: 'joono-prd-portfolio',
+      imageTagMutability: ecr.TagMutability.IMMUTABLE,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    this.repository.addLifecycleRule({
+      rulePriority: 1,
+      description: 'Remove untagged images older than 7 days',
+      tagStatus: ecr.TagStatus.UNTAGGED,
+      maxImageAge: cdk.Duration.days(7),
+    });
+
+    this.repository.addLifecycleRule({
+      rulePriority: 2,
+      description: 'Keep only the 10 most recent tagged images',
+      tagStatus: ecr.TagStatus.TAGGED,
+      tagPrefixList: [''],
+      maxImageCount: 10,
+    });
+  }
+}

--- a/aws/lib/github-actions-role.ts
+++ b/aws/lib/github-actions-role.ts
@@ -6,6 +6,9 @@ export class GitHubActionsRole extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
+    const account = this.account;
+    const region = this.region;
+
     // OIDC Provider for GitHub Actions
     const provider = new iam.OpenIdConnectProvider(this, 'GitHubProvider', {
       url: 'https://token.actions.githubusercontent.com',
@@ -27,9 +30,55 @@ export class GitHubActionsRole extends cdk.Stack {
         }
       ),
       managedPolicies: [
+        // Retained until scoped permissions below are validated in production (Requirement 6.4)
         iam.ManagedPolicy.fromAwsManagedPolicyName('PowerUserAccess'),
       ],
     });
+
+    // Scoped inline policy — least-privilege permissions for the CI/CD pipeline
+    role.addToPolicy(new iam.PolicyStatement({
+      sid: 'ECRAuthToken',
+      effect: iam.Effect.ALLOW,
+      actions: ['ecr:GetAuthorizationToken'],
+      resources: ['*'], // GetAuthorizationToken is a global action; cannot be scoped to a repo ARN
+    }));
+
+    role.addToPolicy(new iam.PolicyStatement({
+      sid: 'ECRImagePush',
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'ecr:BatchCheckLayerAvailability',
+        'ecr:PutImage',
+        'ecr:InitiateLayerUpload',
+        'ecr:UploadLayerPart',
+        'ecr:CompleteLayerUpload',
+      ],
+      // Scoped to the joono-prd-portfolio ECR repository (Requirement 6.1)
+      resources: [
+        `arn:aws:ecr:${region}:${account}:repository/joono-prd-portfolio`,
+      ],
+    }));
+
+    role.addToPolicy(new iam.PolicyStatement({
+      sid: 'LambdaUpdateFunctionCode',
+      effect: iam.Effect.ALLOW,
+      actions: ['lambda:UpdateFunctionCode'],
+      // Scoped to the joono-prd-portfolio-fn Lambda function (Requirement 6.2)
+      resources: [
+        `arn:aws:lambda:${region}:${account}:function:joono-prd-portfolio-fn`,
+      ],
+    }));
+
+    role.addToPolicy(new iam.PolicyStatement({
+      sid: 'CloudFrontInvalidation',
+      effect: iam.Effect.ALLOW,
+      actions: ['cloudfront:CreateInvalidation'],
+      // Scoped to all CloudFront distributions in the account (Requirement 6.3)
+      // CloudFront is a global service; distribution ARNs use us-east-1 as the region
+      resources: [
+        `arn:aws:cloudfront::${account}:distribution/*`,
+      ],
+    }));
 
     new cdk.CfnOutput(this, 'RoleArn', {
       value: role.roleArn,

--- a/aws/lib/notification-system.ts
+++ b/aws/lib/notification-system.ts
@@ -15,7 +15,10 @@ export class PortfolioNotificationStack extends cdk.Stack {
     /* SQS */
     const pageViewQueue = new sqs.Queue(this, 'PageViewQueue', {
       visibilityTimeout: cdk.Duration.seconds(60),
-      retentionPeriod: cdk.Duration.days(4)
+      retentionPeriod: cdk.Duration.days(4),
+      fifo: true,
+      queueName: 'PageViewQueue.fifo',
+      contentBasedDeduplication: false
     });
 
     /* Lambda: Ingest */
@@ -36,7 +39,9 @@ export class PortfolioNotificationStack extends cdk.Stack {
           };
           await sqs.send(new SendMessageCommand({
             QueueUrl: process.env.QUEUE_URL,
-            MessageBody: JSON.stringify(msg)
+            MessageBody: JSON.stringify(msg),
+            MessageDeduplicationId: event.requestContext.http.sourceIp,
+            MessageGroupId: 'pageview'
           }));
           return { statusCode: 200 };
         };

--- a/aws/lib/portfoliostack.ts
+++ b/aws/lib/portfoliostack.ts
@@ -1,31 +1,33 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+
+export interface PortfolioCdkStackProps extends cdk.StackProps {
+  readonly ecrRepo: ecr.IRepository;
+  readonly imageTag?: string;
+}
 
 export class PortfolioCdkStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+  public readonly functionUrl: lambda.FunctionUrl;
+
+  constructor(scope: Construct, id: string, props: PortfolioCdkStackProps) {
     super(scope, id, props);
 
-    // Deploy the standalone Next.js output from `.next/standalone/app.zip`
-    const portfolioFunction = new lambda.Function(this, 'PortfolioLambda', {
+    const { ecrRepo, imageTag = 'latest' } = props;
+
+    const portfolioFunction = new lambda.DockerImageFunction(this, 'PortfolioLambda', {
       functionName: 'joono-prd-portfolio-fn',
-      runtime: lambda.Runtime.NODEJS_20_X,
-      handler: 'run.sh',
-      code: lambda.Code.fromAsset('../nextjs-app/.next/standalone/app.zip'),
+      code: lambda.DockerImageCode.fromEcr(ecrRepo, { tagOrDigest: imageTag }),
       memorySize: 512,
       timeout: cdk.Duration.seconds(30),
       environment: {
-        PORT: '8000',
-        AWS_LAMBDA_EXEC_WRAPPER: '/opt/bootstrap',
         NODE_ENV: 'production',
       },
-      layers: [
-        lambda.LayerVersion.fromLayerVersionArn(
-          this,
-          'LambdaAdapterLayer',
-          `arn:aws:lambda:ap-southeast-2:753240598075:layer:LambdaAdapterLayerX86:25`
-        ),
-      ],
+    });
+
+    this.functionUrl = portfolioFunction.addFunctionUrl({
+      authType: lambda.FunctionUrlAuthType.AWS_IAM,
     });
   }
 }

--- a/nextjs-app/Dockerfile
+++ b/nextjs-app/Dockerfile
@@ -1,0 +1,35 @@
+# Stage 1: Install production dependencies
+FROM node:18-alpine AS deps
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# Stage 2: Build the Next.js application
+FROM node:18-alpine AS builder
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# Stage 3: Production runner using standalone output
+FROM node:18-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Copy the standalone server bundle
+COPY --from=builder /app/.next/standalone ./
+
+# Copy static assets
+COPY --from=builder /app/.next/static ./.next/static
+
+# Copy public assets
+COPY --from=builder /app/public ./public
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/nextjs-app/package-lock.json
+++ b/nextjs-app/package-lock.json
@@ -11,6 +11,7 @@
         "@react-pdf/renderer": "^3.4.4",
         "eslint-config-wesbos": "^4.0.1",
         "framer-motion": "^12.23.6",
+        "graphql-request": "6.1.0",
         "next": "14.2.3",
         "react": "^18",
         "react-dom": "^18",
@@ -624,6 +625,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4493,6 +4503,29 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "license": "MIT"
+    },
+    "node_modules/graphql": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
+      "integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "cross-fetch": "^3.1.5"
+      },
+      "peerDependencies": {
+        "graphql": "14 - 16"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",

--- a/nextjs-app/package.json
+++ b/nextjs-app/package.json
@@ -14,13 +14,14 @@
     "@react-pdf/renderer": "^3.4.4",
     "eslint-config-wesbos": "^4.0.1",
     "framer-motion": "^12.23.6",
+    "graphql-request": "6.1.0",
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18",
     "react-intersection-observer": "^9.16.0",
     "react-pdf": "^9.0.0",
-    "tailwindcss-animated": "^1.1.2",
-    "tailwindcss": "^3.4.1"
+    "tailwindcss": "^3.4.1",
+    "tailwindcss-animated": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",

--- a/nextjs-app/src/app/blogs/page.tsx
+++ b/nextjs-app/src/app/blogs/page.tsx
@@ -31,6 +31,8 @@
 
 
 
+export const dynamic = 'force-dynamic';
+
 import Image from 'next/image';
 import Link from 'next/link';
 import { gql } from 'graphql-request';


### PR DESCRIPTION
- Add Dockerfile for Next.js standalone build
- Add joono-prd-ecr CDK stack with ECR repository and lifecycle policy
- Refactor PortfolioCdkStack to DockerImageFunction (joono-prd-portfolio)
- Replace standard SQS queue with FIFO queue in notifications stack
- Add scoped ECR/Lambda/CloudFront IAM permissions to GitHubActionsRole
- Update CDK app entry point with joono-prd-<service> stack naming
- Rewrite GitHub Actions deploy workflow for Docker build/push pipeline
- Update aws/README.md with new stack names, ECR section, and migration notes